### PR TITLE
Suport for Custom Domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+feeds.sycl.tech


### PR DESCRIPTION
This PR adds support to allow feeds.sycl.tech domain resolution.