### PR TITLE
Adding Performance Portability Training Series Blog

### DIFF
--- a/content/news/2024/2024-06-20-performance-portability-training-series.md
+++ b/content/news/2024/2024-06-20-performance-portability-training-series.md
@@ -1,0 +1,18 @@
+---
+contributor: max
+date: '2024-06-20T14:10:22.153253'
+external_url: https://www.alcf.anl.gov/events/portable-sycl-code-using-onemkl-amd-intel-and-nvidia-gpus
+title: 'Portable SYCL Code Using oneMKL on AMD, Intel, and Nvidia GPUs'
+image: ../../../static/images/news/2024-06-20 performance-portability-series.webp
+tags:
+  - performance
+  - hpc
+  - oneapi
+  - portability
+  - cuda
+---
+
+Portable SYCL code using oneMKL on AMD, Intel, and Nvidia GPUs, presented by CodePlay and Intel, is part of the Performance Portability training series. 
+Offered by NERSC, OLCF, and ALCF, the series features training sessions on various performance portable programming solutions to help ease developer transitions 
+between current and emerging high-performance computing (HPC) systems, such as the NERSC Perlmutter and ALCF Polaris (AMD CPU and Nvidia GPU), OLCF Frontier (AMD CPU and GPU), 
+and ALCF Aurora (Intel CPU and GPU).


### PR DESCRIPTION
This PR merges the two branches for the Performance Portability Training Series Blog.