### PR TITLE
Remove Research Paper Affiliations

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -32,8 +32,7 @@ jobs:
           -s "${{ vars.CI_PAGES_URL }}" \
           -a "${{ vars.CI_PAGES_URL }}/static/" \
           -b "${{ vars.CI_PAGES_URL }}/feed" \
-          -g "${{ secrets.FRONT_END_REBUILD_TOKEN }}" \
-          -d
+          -g "${{ secrets.FRONT_END_REBUILD_TOKEN }}"
     - name: Copy Generate Feeds
       run: |
         cp -R html/. static feed/

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -32,7 +32,7 @@ jobs:
           -s "${{ vars.CI_PAGES_URL }}" \
           -a "${{ vars.CI_PAGES_URL }}/static/" \
           -b "${{ vars.CI_PAGES_URL }}/feed" \
-          -g "${{ secrets.FRONT_END_REBUILD_TOKEN }}"
+          -g "${{ secrets.FRONT_END_REBUILD_TOKEN }}" \
           -d
     - name: Copy Generate Feeds
       run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,6 +33,7 @@ jobs:
           -a "${{ vars.CI_PAGES_URL }}/static/" \
           -b "${{ vars.CI_PAGES_URL }}/feed" \
           -g "${{ secrets.FRONT_END_REBUILD_TOKEN }}"
+          -d
     - name: Copy Generate Feeds
       run: |
         cp -R html/. static feed/

--- a/content/research_papers/2016/2016-10-26-a-comparative-study-of-sycl-open-cl-and-open-mp.md
+++ b/content/research_papers/2016/2016-10-26-a-comparative-study-of-sycl-open-cl-and-open-mp.md
@@ -4,9 +4,9 @@ date: '2016-10-26T10:57:29+01:00'
 title: 'A Comparative Study of SYCL, OpenCL, and OpenMP'
 external_url: https://ieeexplore.ieee.org/document/7803697
 authors:
-  - name: Hércules Cardoso da Silva
-  - name: Flávia Pisani
-  - name: Edson Borin
+  - Hércules Cardoso da Silva
+  - Flávia Pisani
+  - Edson Borin
 tags:
   - opencl
   - openmp

--- a/content/research_papers/2016/2016-10-26-a-comparative-study-of-sycl-open-cl-and-open-mp.md
+++ b/content/research_papers/2016/2016-10-26-a-comparative-study-of-sycl-open-cl-and-open-mp.md
@@ -5,11 +5,8 @@ title: 'A Comparative Study of SYCL, OpenCL, and OpenMP'
 external_url: https://ieeexplore.ieee.org/document/7803697
 authors:
   - name: Hércules Cardoso da Silva
-    affiliation: Inst. of Comput
   - name: Flávia Pisani
-    affiliation: Institute of Computing,
   - name: Edson Borin
-    affiliation: Institute of Computing
 tags:
   - opencl
   - openmp

--- a/content/research_papers/2018/2018-07-10-solving-maxwells-equations-with-modern-c-and-sycl-a-case-study.md
+++ b/content/research_papers/2018/2018-07-10-solving-maxwells-equations-with-modern-c-and-sycl-a-case-study.md
@@ -5,19 +5,12 @@ title: 'Solving Maxwells Equations with Modern C++ and SYCL: A Case Study'
 external_url: https://ieeexplore.ieee.org/document/8445127
 authors:
   - name: Ayesha Afzal
-    affiliation: Friedrich-Alexander university Erlangen-Nurnberg
   - name: Christian Schmitt
-    affiliation: Friedrich-Alexander university Erlangen-Nurnberg
   - name: Samer Alhaddad
-    affiliation: Paderborn University
   - name: Yevgen Grynko
-    affiliation: Paderborn University
   - name: Jurgen Teich
-    affiliation: Friedrich-Alexander university Erlangen-Nurnberg
   - name: Jens Forstner
-    affiliation: Paderborn University
   - name: Frank Hannig
-    affiliation: Friedrich-Alexander university Erlangen-Nurnberg
 tags:
   - maxwell
   - c++

--- a/content/research_papers/2018/2018-07-10-solving-maxwells-equations-with-modern-c-and-sycl-a-case-study.md
+++ b/content/research_papers/2018/2018-07-10-solving-maxwells-equations-with-modern-c-and-sycl-a-case-study.md
@@ -4,13 +4,13 @@ date: '2018-07-10T08:08:10.490000+00:00'
 title: 'Solving Maxwells Equations with Modern C++ and SYCL: A Case Study'
 external_url: https://ieeexplore.ieee.org/document/8445127
 authors:
-  - name: Ayesha Afzal
-  - name: Christian Schmitt
-  - name: Samer Alhaddad
-  - name: Yevgen Grynko
-  - name: Jurgen Teich
-  - name: Jens Forstner
-  - name: Frank Hannig
+  - Ayesha Afzal
+  - Christian Schmitt
+  - Samer Alhaddad
+  - Yevgen Grynko
+  - Jurgen Teich
+  - Jens Forstner
+  - Frank Hannig
 tags:
   - maxwell
   - c++

--- a/content/research_papers/2019/2019-09-02-celerity-high-level-c-for-accelerator-clusters.md
+++ b/content/research_papers/2019/2019-09-02-celerity-high-level-c-for-accelerator-clusters.md
@@ -5,13 +5,9 @@ title: 'Celerity: High-level C++ for Accelerator Clusters'
 external_url: https://www.cosenza.eu/papers/ThomanEUROPAR19.pdf
 authors:
   - name: Peter Thoman
-    affiliation: University of Innsbruck
   - name: Philip Salzmann
-    affiliation: University of Innsbruck
   - name: Biagio Cosenza
-    affiliation: TU Berlin
   - name: Thomas Fahringer
-    affiliation: University of Innsbruck
 tags:
   - clusters
   - scientific

--- a/content/research_papers/2019/2019-09-02-celerity-high-level-c-for-accelerator-clusters.md
+++ b/content/research_papers/2019/2019-09-02-celerity-high-level-c-for-accelerator-clusters.md
@@ -4,10 +4,10 @@ date: '2019-09-02T10:57:29+01:00'
 title: 'Celerity: High-level C++ for Accelerator Clusters'
 external_url: https://www.cosenza.eu/papers/ThomanEUROPAR19.pdf
 authors:
-  - name: Peter Thoman
-  - name: Philip Salzmann
-  - name: Biagio Cosenza
-  - name: Thomas Fahringer
+  - Peter Thoman
+  - Philip Salzmann
+  - Biagio Cosenza
+  - Thomas Fahringer
 tags:
   - clusters
   - scientific

--- a/content/research_papers/2019/2019-09-02-improving-the-performance-of-medical-imaging-applications-using-sycl.md
+++ b/content/research_papers/2019/2019-09-02-improving-the-performance-of-medical-imaging-applications-using-sycl.md
@@ -5,7 +5,6 @@ title: Improving the Performance of Medical Imaging Applications using SYCL
 external_url: https://publications.anl.gov/anlpubs/2019/12/157485.pdf
 authors:
   - name: Zheming Jin
-    affiliation: Argonne Leadership Computing Facility
 tags:
   - medical
   - scientific

--- a/content/research_papers/2019/2019-09-02-improving-the-performance-of-medical-imaging-applications-using-sycl.md
+++ b/content/research_papers/2019/2019-09-02-improving-the-performance-of-medical-imaging-applications-using-sycl.md
@@ -4,7 +4,7 @@ date: '2019-09-02T10:57:29+01:00'
 title: Improving the Performance of Medical Imaging Applications using SYCL
 external_url: https://publications.anl.gov/anlpubs/2019/12/157485.pdf
 authors:
-  - name: Zheming Jin
+  - Zheming Jin
 tags:
   - medical
   - scientific

--- a/content/research_papers/2019/2019-09-02-innovative-language-extensions-for-accelerator-cards-using-the-example-of-sycl-hc-hip-and-cuda-research-on-usability-and-performance.md
+++ b/content/research_papers/2019/2019-09-02-innovative-language-extensions-for-accelerator-cards-using-the-example-of-sycl-hc-hip-and-cuda-research-on-usability-and-performance.md
@@ -6,7 +6,6 @@ title: 'Innovative language extensions for accelerator cards using the example o
 external_url: https://github.com/j-stephan/fpg/blob/master/paper.pdf
 authors:
   - name: Jan Stephan
-    affiliation: Technische Universität Dresden
 tags:
   - benchmarking
   - cuda

--- a/content/research_papers/2019/2019-09-02-innovative-language-extensions-for-accelerator-cards-using-the-example-of-sycl-hc-hip-and-cuda-research-on-usability-and-performance.md
+++ b/content/research_papers/2019/2019-09-02-innovative-language-extensions-for-accelerator-cards-using-the-example-of-sycl-hc-hip-and-cuda-research-on-usability-and-performance.md
@@ -5,7 +5,7 @@ title: 'Innovative language extensions for accelerator cards using the example o
   SYCL, HC, HIP and CUDA: research on usability and performance'
 external_url: https://github.com/j-stephan/fpg/blob/master/paper.pdf
 authors:
-  - name: Jan Stephan
+  - Jan Stephan
 tags:
   - benchmarking
   - cuda

--- a/content/research_papers/2019/2019-09-02-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
+++ b/content/research_papers/2019/2019-09-02-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
@@ -5,21 +5,14 @@ title: Performance portability of a Wilson Dslash Stencil Operator Mini-App usin
 external_url: https://sc19.supercomputing.org/proceedings/workshops/workshop_files/ws_p3hpc116s2-file1.pdf
 authors:
   - name: Bálint Joó
-    affiliation: Jefferson Lab
+    
   - name: Thorsten Kurth
-    affiliation: NERSC
   - name: M. A. Clark
-    affiliation: NVIDIA
   - name: Jeongnim Kim
-    affiliation: Intel Corporation
   - name: Christian R. Trott
-    affiliation: Sandia National Laboratories
   - name: Dan Ibanez
-    affiliation: Sandia National Laboratories
   - name: Dan Sunderland
-    affiliation: Sandia National Laboratories
   - name: Jack Deslippe
-    affiliation: NERSC
 tags:
   - portability
   - benchmarking

--- a/content/research_papers/2019/2019-09-02-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
+++ b/content/research_papers/2019/2019-09-02-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
@@ -4,15 +4,15 @@ date: '2019-09-02T10:57:29+01:00'
 title: Performance portability of a Wilson Dslash Stencil Operator Mini-App using Kokkos and SYCL
 external_url: https://sc19.supercomputing.org/proceedings/workshops/workshop_files/ws_p3hpc116s2-file1.pdf
 authors:
-  - name: Bálint Joó
+  - Bálint Joó
     
-  - name: Thorsten Kurth
-  - name: M. A. Clark
-  - name: Jeongnim Kim
-  - name: Christian R. Trott
-  - name: Dan Ibanez
-  - name: Dan Sunderland
-  - name: Jack Deslippe
+  - Thorsten Kurth
+  - M. A. Clark
+  - Jeongnim Kim
+  - Christian R. Trott
+  - Dan Ibanez
+  - Dan Sunderland
+  - Jack Deslippe
 tags:
   - portability
   - benchmarking

--- a/content/research_papers/2019/2019-09-02-performance-portability-of-multi-material-kernels.md
+++ b/content/research_papers/2019/2019-09-02-performance-portability-of-multi-material-kernels.md
@@ -4,7 +4,7 @@ date: '2019-09-02T10:57:29+01:00'
 title: Performance Portability of Multi-Material Kernels
 external_url: https://sc19.supercomputing.org/proceedings/workshops/workshop_files/ws_p3hpc106s2-file1.pdf
 authors:
-  - name: Istvan Z. Reguly
+  - Istvan Z. Reguly
 tags:
   - portability
   - performance

--- a/content/research_papers/2019/2019-09-02-performance-portability-of-multi-material-kernels.md
+++ b/content/research_papers/2019/2019-09-02-performance-portability-of-multi-material-kernels.md
@@ -5,7 +5,6 @@ title: Performance Portability of Multi-Material Kernels
 external_url: https://sc19.supercomputing.org/proceedings/workshops/workshop_files/ws_p3hpc106s2-file1.pdf
 authors:
   - name: Istvan Z. Reguly
-    affiliation: Faculty of Information Technology and Bionics Pazmany Peter Catholic University
 tags:
   - portability
   - performance

--- a/content/research_papers/2019/2019-09-02-sycl-code-generation-for-multigrid-methods.md
+++ b/content/research_papers/2019/2019-09-02-sycl-code-generation-for-multigrid-methods.md
@@ -5,13 +5,9 @@ title: SYCL Code Generation for Multigrid Methods
 external_url: https://www.researchgate.net/publication/333139223_SYCL_Code_Generation_for_Multigrid_Methods
 authors:
   - name: Stefan Groth
-    affiliation: Unknown
   - name: Christian Schmitt
-    affiliation: Friedrich-Alexander-University of Erlangen-Nürnberg
   - name: Jürgen Teich
-    affiliation: Unknown
   - name: Frank Hannig
-    affiliation: Friedrich-Alexander-University of Erlangen-Nürnberg
 tags:
   - multigrid
   - c++

--- a/content/research_papers/2019/2019-09-02-sycl-code-generation-for-multigrid-methods.md
+++ b/content/research_papers/2019/2019-09-02-sycl-code-generation-for-multigrid-methods.md
@@ -4,10 +4,10 @@ date: '2019-09-02T10:57:29+01:00'
 title: SYCL Code Generation for Multigrid Methods
 external_url: https://www.researchgate.net/publication/333139223_SYCL_Code_Generation_for_Multigrid_Methods
 authors:
-  - name: Stefan Groth
-  - name: Christian Schmitt
-  - name: Jürgen Teich
-  - name: Frank Hannig
+  - Stefan Groth
+  - Christian Schmitt
+  - Jürgen Teich
+  - Frank Hannig
 tags:
   - multigrid
   - c++

--- a/content/research_papers/2019/2019-11-18-evaluation-of-medical-imaging-applications-using-sycl.md
+++ b/content/research_papers/2019/2019-11-18-evaluation-of-medical-imaging-applications-using-sycl.md
@@ -4,8 +4,8 @@ date: '2019-11-18T10:57:29+01:00'
 title: Evaluation of Medical Imaging Applications using SYCL
 external_url: https://ieeexplore.ieee.org/document/8982983
 authors:
-  - name: Zheming Jin
-  - name: Hal Finkel
+  - Zheming Jin
+  - Hal Finkel
 tags:
   - benchmark
   - performance

--- a/content/research_papers/2019/2019-11-18-evaluation-of-medical-imaging-applications-using-sycl.md
+++ b/content/research_papers/2019/2019-11-18-evaluation-of-medical-imaging-applications-using-sycl.md
@@ -5,9 +5,7 @@ title: Evaluation of Medical Imaging Applications using SYCL
 external_url: https://ieeexplore.ieee.org/document/8982983
 authors:
   - name: Zheming Jin
-    affiliation: Argonne National Laboratory
   - name: Hal Finkel
-    affiliation: Argonne National Laboratory
 tags:
   - benchmark
   - performance

--- a/content/research_papers/2019/2019-11-22-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
+++ b/content/research_papers/2019/2019-11-22-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
@@ -4,14 +4,14 @@ date: '2019-11-22T10:57:29+01:00'
 title: 'Performance Portability of a Wilson Dslash Stencil Operator Mini-App Using Kokkos and SYCL'
 external_url: https://ieeexplore.ieee.org/document/8945798
 authors:
-  - name: Bálint Joó
-  - name: Thorsten Kurth
-  - name: M. A. Clark
-  - name: Jeongnim Kim
-  - name: Christian Robert Trott
-  - name: Dan Ibanez
-  - name: Daniel Sunderland
-  - name: Jack Deslippe
+  - Bálint Joó
+  - Thorsten Kurth
+  - M. A. Clark
+  - Jeongnim Kim
+  - Christian Robert Trott
+  - Dan Ibanez
+  - Daniel Sunderland
+  - Jack Deslippe
 tags:
   - kokkos
   - performance

--- a/content/research_papers/2019/2019-11-22-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
+++ b/content/research_papers/2019/2019-11-22-performance-portability-of-a-wilson-dslash-stencil-operator-mini-app-using-kokkos-and-sycl.md
@@ -5,21 +5,13 @@ title: 'Performance Portability of a Wilson Dslash Stencil Operator Mini-App Usi
 external_url: https://ieeexplore.ieee.org/document/8945798
 authors:
   - name: Bálint Joó
-    affiliation: Jefferson Lab
   - name: Thorsten Kurth
-    affiliation: NERSC
   - name: M. A. Clark
-    affiliation: NVIDIA
   - name: Jeongnim Kim
-    affiliation: Intel Corporation
   - name: Christian Robert Trott
-    affiliation: Sandia National Laboratories
   - name: Dan Ibanez
-    affiliation: Sandia National Laboratories
   - name: Daniel Sunderland
-    affiliation: Sandia National Laboratories
   - name: Jack Deslippe
-    affiliation: NERSC
 tags:
   - kokkos
   - performance

--- a/content/research_papers/2019/2019-12-09-a-case-study-of-k-means-clustering-using-sycl.md
+++ b/content/research_papers/2019/2019-12-09-a-case-study-of-k-means-clustering-using-sycl.md
@@ -4,8 +4,8 @@ date: '2019-12-09T10:57:29+01:00'
 title: A Case Study of k-means Clustering using SYCL
 external_url: https://ieeexplore.ieee.org/document/9005555
 authors:
-  - name: Zheming Jin
-  - name: Hal Finkel
+  - Zheming Jin
+  - Hal Finkel
 tags:
   - benchmark
   - energy-consumption

--- a/content/research_papers/2019/2019-12-09-a-case-study-of-k-means-clustering-using-sycl.md
+++ b/content/research_papers/2019/2019-12-09-a-case-study-of-k-means-clustering-using-sycl.md
@@ -5,9 +5,7 @@ title: A Case Study of k-means Clustering using SYCL
 external_url: https://ieeexplore.ieee.org/document/9005555
 authors:
   - name: Zheming Jin
-    affiliation: Argonne National Laboratory
   - name: Hal Finkel
-    affiliation: Argonne National Laboratory
 tags:
   - benchmark
   - energy-consumption

--- a/content/research_papers/2020/2020-05-18-a-case-study-on-the-hac-cmk-routine-in-sycl-on-integrated-graphics.md
+++ b/content/research_papers/2020/2020-05-18-a-case-study-on-the-hac-cmk-routine-in-sycl-on-integrated-graphics.md
@@ -5,11 +5,8 @@ title: 'A Case Study on the HACCmk Routine in SYCL on Integrated Graphics'
 external_url: https://ieeexplore.ieee.org/document/9150310
 authors:
   - name: Zheming Jin
-    affiliation: Argonne National Laboratory
   - name: Vitali Morozov
-    affiliation: Argonne National Laboratory
   - name: Hal Finkel
-    affiliation: Argonne National Laboratory
 tags:
   - compute
   - haccmk

--- a/content/research_papers/2020/2020-05-18-a-case-study-on-the-hac-cmk-routine-in-sycl-on-integrated-graphics.md
+++ b/content/research_papers/2020/2020-05-18-a-case-study-on-the-hac-cmk-routine-in-sycl-on-integrated-graphics.md
@@ -4,9 +4,9 @@ date: '2022-05-18T08:08:10.490000+00:00'
 title: 'A Case Study on the HACCmk Routine in SYCL on Integrated Graphics'
 external_url: https://ieeexplore.ieee.org/document/9150310
 authors:
-  - name: Zheming Jin
-  - name: Vitali Morozov
-  - name: Hal Finkel
+  - Zheming Jin
+  - Vitali Morozov
+  - Hal Finkel
 tags:
   - compute
   - haccmk

--- a/content/research_papers/2020/2020-05-18-towards-automated-kernel-selection-in-machine-learning-systems-a-sycl-case-study.md
+++ b/content/research_papers/2020/2020-05-18-towards-automated-kernel-selection-in-machine-learning-systems-a-sycl-case-study.md
@@ -5,7 +5,6 @@ title: 'Towards automated kernel selection in machine learning systems: A SYCL c
 external_url: https://ieeexplore.ieee.org/document/9150358
 authors:
   - name: John Lawson
-    affiliation: Codeplay Software Ltd
 tags:
   - tuning
   - sycl

--- a/content/research_papers/2020/2020-05-18-towards-automated-kernel-selection-in-machine-learning-systems-a-sycl-case-study.md
+++ b/content/research_papers/2020/2020-05-18-towards-automated-kernel-selection-in-machine-learning-systems-a-sycl-case-study.md
@@ -4,7 +4,7 @@ date: '2022-05-18T08:08:10.490000+00:00'
 title: 'Towards automated kernel selection in machine learning systems: A SYCL case study'
 external_url: https://ieeexplore.ieee.org/document/9150358
 authors:
-  - name: John Lawson
+  - John Lawson
 tags:
   - tuning
   - sycl

--- a/content/research_papers/2020/2020-11-13-evaluating-the-performance-and-portability-of-contemporary-sycl-implementations.md
+++ b/content/research_papers/2020/2020-11-13-evaluating-the-performance-and-portability-of-contemporary-sycl-implementations.md
@@ -4,9 +4,9 @@ date: '2020-11-13T08:08:10.490000+00:00'
 title: 'Evaluating the Performance and Portability of Contemporary SYCL Implementations'
 external_url: https://ieeexplore.ieee.org/document/9309045
 authors:
-  - name: Beau Johnston
-  - name: Jeffrey S. Vetter
-  - name: Josh Milthorpe
+  - Beau Johnston
+  - Jeffrey S. Vetter
+  - Josh Milthorpe
 tags:
   - benchmarks
   - performance

--- a/content/research_papers/2020/2020-11-13-evaluating-the-performance-and-portability-of-contemporary-sycl-implementations.md
+++ b/content/research_papers/2020/2020-11-13-evaluating-the-performance-and-portability-of-contemporary-sycl-implementations.md
@@ -5,11 +5,8 @@ title: 'Evaluating the Performance and Portability of Contemporary SYCL Implemen
 external_url: https://ieeexplore.ieee.org/document/9309045
 authors:
   - name: Beau Johnston
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
   - name: Josh Milthorpe
-    affiliation: Australian National University
 tags:
   - benchmarks
   - performance

--- a/content/research_papers/2021/2021-09-07-automatic-parallelization-of-structured-mesh-computations-with-sycl.md
+++ b/content/research_papers/2021/2021-09-07-automatic-parallelization-of-structured-mesh-computations-with-sycl.md
@@ -4,8 +4,8 @@ date: '2021-06-07T08:08:10.490000+00:00'
 title: 'Automatic Parallelization of Structured Mesh Computations with SYCL'
 external_url: https://ieeexplore.ieee.org/document/9555976
 authors:
-  - name: Gábor Dániel Balogh
-  - name: István Reguly
+  - Gábor Dániel Balogh
+  - István Reguly
 tags:
   - parallel-programming
   - nvidia

--- a/content/research_papers/2021/2021-09-07-automatic-parallelization-of-structured-mesh-computations-with-sycl.md
+++ b/content/research_papers/2021/2021-09-07-automatic-parallelization-of-structured-mesh-computations-with-sycl.md
@@ -5,9 +5,7 @@ title: 'Automatic Parallelization of Structured Mesh Computations with SYCL'
 external_url: https://ieeexplore.ieee.org/document/9555976
 authors:
   - name: Gábor Dániel Balogh
-    affiliation: Pázmány Péter Catholic University
   - name: István Reguly
-    affiliation: Pázmány Péter Catholic University
 tags:
   - parallel-programming
   - nvidia

--- a/content/research_papers/2021/2021-11-14-benchmarking-and-extending-sycl-hierarchical-parallelism.md
+++ b/content/research_papers/2021/2021-11-14-benchmarking-and-extending-sycl-hierarchical-parallelism.md
@@ -5,13 +5,9 @@ title: 'Benchmarking and Extending SYCL Hierarchical Parallelism'
 external_url: https://ieeexplore.ieee.org/document/9654235
 authors:
   - name: Tom Deakin
-    affiliation: University of Bristol
   - name: Simon McIntosh-Smith
-    affiliation: University of Bristol
   - name: Aksel Alpay
-    affiliation:  Universität Heidelberg
   - name: Vincent Heuveline
-    affiliation: Universität Heidelberg
 tags:
   - benchmarks
   - extending

--- a/content/research_papers/2021/2021-11-14-benchmarking-and-extending-sycl-hierarchical-parallelism.md
+++ b/content/research_papers/2021/2021-11-14-benchmarking-and-extending-sycl-hierarchical-parallelism.md
@@ -4,10 +4,10 @@ date: '2021-11-14T08:08:10.490000+00:00'
 title: 'Benchmarking and Extending SYCL Hierarchical Parallelism'
 external_url: https://ieeexplore.ieee.org/document/9654235
 authors:
-  - name: Tom Deakin
-  - name: Simon McIntosh-Smith
-  - name: Aksel Alpay
-  - name: Vincent Heuveline
+  - Tom Deakin
+  - Simon McIntosh-Smith
+  - Aksel Alpay
+  - Vincent Heuveline
 tags:
   - benchmarks
   - extending

--- a/content/research_papers/2021/2021-11-14-case-study-of-using-kokkos-and-sycl-as-performance-portable-frameworks-for-milc-dslash-benchmark-on-nvidia-amd-and-intel-gp-us.md
+++ b/content/research_papers/2021/2021-11-14-case-study-of-using-kokkos-and-sycl-as-performance-portable-frameworks-for-milc-dslash-benchmark-on-nvidia-amd-and-intel-gp-us.md
@@ -5,19 +5,12 @@ title: 'Case Study of Using Kokkos and SYCL as Performance-Portable Frameworks f
 external_url: https://ieeexplore.ieee.org/document/9652859
 authors:
   - name: Amanda S. Dufek
-    affiliation: NERSC/LBNL
   - name: Rahulkumar Gayatri
-    affiliation: NERSC/LBNL
   - name: Neil Mehta
-    affiliation: NERSC/LBNL
   - name: Douglas Doerfler
-    affiliation: NERSC/LBNL
   - name: Brandon Cook
-    affiliation: NERSC/LBNL
   - name: Yasaman Ghadar
-    affiliation: Argonne National Laboratory
   - name: Carleton DeTar
-    affiliation: University of Utah
 tags:
   - kokkos
   - milc-dslash

--- a/content/research_papers/2021/2021-11-14-case-study-of-using-kokkos-and-sycl-as-performance-portable-frameworks-for-milc-dslash-benchmark-on-nvidia-amd-and-intel-gp-us.md
+++ b/content/research_papers/2021/2021-11-14-case-study-of-using-kokkos-and-sycl-as-performance-portable-frameworks-for-milc-dslash-benchmark-on-nvidia-amd-and-intel-gp-us.md
@@ -4,13 +4,13 @@ date: '2021-11-14T08:08:10.490000+00:00'
 title: 'Case Study of Using Kokkos and SYCL as Performance-Portable Frameworks for Milc-Dslash Benchmark on NVIDIA, AMD and Intel GPUs'
 external_url: https://ieeexplore.ieee.org/document/9652859
 authors:
-  - name: Amanda S. Dufek
-  - name: Rahulkumar Gayatri
-  - name: Neil Mehta
-  - name: Douglas Doerfler
-  - name: Brandon Cook
-  - name: Yasaman Ghadar
-  - name: Carleton DeTar
+  - Amanda S. Dufek
+  - Rahulkumar Gayatri
+  - Neil Mehta
+  - Douglas Doerfler
+  - Brandon Cook
+  - Yasaman Ghadar
+  - Carleton DeTar
 tags:
   - kokkos
   - milc-dslash

--- a/content/research_papers/2021/2021-11-24-efficient-hardware-agnostic-dbms-operator-implementation-using-sycl.md
+++ b/content/research_papers/2021/2021-11-24-efficient-hardware-agnostic-dbms-operator-implementation-using-sycl.md
@@ -5,11 +5,8 @@ title: 'Efficient Hardware-Agnostic DBMS Operator Implementation Using SYCL'
 external_url: https://ieeexplore.ieee.org/document/9681747
 authors:
   - name: Daniil Kulikov
-    affiliation: SPbU
   - name: Daria Nikolskaia
-    affiliation: ITMO
   - name: Petr Kurapov
-    affiliation: MIPT
 tags:
   - parallel programming
   - hash-join

--- a/content/research_papers/2021/2021-11-24-efficient-hardware-agnostic-dbms-operator-implementation-using-sycl.md
+++ b/content/research_papers/2021/2021-11-24-efficient-hardware-agnostic-dbms-operator-implementation-using-sycl.md
@@ -4,9 +4,9 @@ date: '2021-11-24T08:08:10.490000+00:00'
 title: 'Efficient Hardware-Agnostic DBMS Operator Implementation Using SYCL'
 external_url: https://ieeexplore.ieee.org/document/9681747
 authors:
-  - name: Daniil Kulikov
-  - name: Daria Nikolskaia
-  - name: Petr Kurapov
+  - Daniil Kulikov
+  - Daria Nikolskaia
+  - Petr Kurapov
 tags:
   - parallel programming
   - hash-join

--- a/content/research_papers/2022/2022-04-14-comparing-sycl-trade-data-transfer-strategies-for-tracking-use-cases.md
+++ b/content/research_papers/2022/2022-04-14-comparing-sycl-trade-data-transfer-strategies-for-tracking-use-cases.md
@@ -4,10 +4,10 @@ date: '2022-04-14T08:08:10.490000+00:00'
 title: Comparing SYCL&trade; Data Transfer Strategies for Tracking Use Cases
 external_url: https://iopscience.iop.org/article/10.1088/1742-6596/2438/1/012018/pdf
 authors:
-  - name: Sylvain Joube
-  - name: Hadrien Grasland
-  - name: David Chamont
-  - name: Elisabeth Brunet
+  - Sylvain Joube
+  - Hadrien Grasland
+  - David Chamont
+  - Elisabeth Brunet
 tags:
   - performance
   - benchmarking

--- a/content/research_papers/2022/2022-04-14-comparing-sycl-trade-data-transfer-strategies-for-tracking-use-cases.md
+++ b/content/research_papers/2022/2022-04-14-comparing-sycl-trade-data-transfer-strategies-for-tracking-use-cases.md
@@ -5,13 +5,9 @@ title: Comparing SYCL&trade; Data Transfer Strategies for Tracking Use Cases
 external_url: https://iopscience.iop.org/article/10.1088/1742-6596/2438/1/012018/pdf
 authors:
   - name: Sylvain Joube
-    affiliation: Universit´e Paris-Saclay
   - name: Hadrien Grasland
-    affiliation: Universit´e Paris-Saclay
   - name: David Chamont
-    affiliation: Universit´e Paris-Saclay
   - name: Elisabeth Brunet
-    affiliation: Institut Polytechnique de Paris
 tags:
   - performance
   - benchmarking

--- a/content/research_papers/2022/2022-04-14-evaluation-of-intel-s-dpc-compatibility-tool-in-heterogeneous-computing.md
+++ b/content/research_papers/2022/2022-04-14-evaluation-of-intel-s-dpc-compatibility-tool-in-heterogeneous-computing.md
@@ -5,13 +5,9 @@ title: Evaluation of Intel's DPC++ Compatibility Tool in heterogeneous computing
 external_url: https://www.sciencedirect.com/science/article/pii/S0743731522000727?via%3Dihub
 authors:
   - name: Germán Castaño
-    affiliation: Informática, Universidad Complutense Madrid
   - name: Youssef Faqir-Rhazoui
-    affiliation: Informática, Universidad Complutense Madrid
   - name: Carlos García
-    affiliation: Informática, Universidad Complutense Madrid
   - name: Manuel Prieto-Matías
-    affiliation: Informática, Universidad Complutense Madrid
 tags:
   - dpcpp
   - oneapi

--- a/content/research_papers/2022/2022-04-14-evaluation-of-intel-s-dpc-compatibility-tool-in-heterogeneous-computing.md
+++ b/content/research_papers/2022/2022-04-14-evaluation-of-intel-s-dpc-compatibility-tool-in-heterogeneous-computing.md
@@ -4,10 +4,10 @@ date: '2022-04-14T08:08:10.490000+00:00'
 title: Evaluation of Intel's DPC++ Compatibility Tool in heterogeneous computing
 external_url: https://www.sciencedirect.com/science/article/pii/S0743731522000727?via%3Dihub
 authors:
-  - name: Germán Castaño
-  - name: Youssef Faqir-Rhazoui
-  - name: Carlos García
-  - name: Manuel Prieto-Matías
+  - Germán Castaño
+  - Youssef Faqir-Rhazoui
+  - Carlos García
+  - Manuel Prieto-Matías
 tags:
   - dpcpp
   - oneapi

--- a/content/research_papers/2022/2022-04-14-fast-merge-tree-computation-via-sycl.md
+++ b/content/research_papers/2022/2022-04-14-fast-merge-tree-computation-via-sycl.md
@@ -4,8 +4,8 @@ date: '2022-04-14T08:08:10.490000+00:00'
 title: Fast Merge Tree Computation via SYCL
 external_url: https://arxiv.org/pdf/2301.10838.pdf
 authors:
-  - name: Arnur Nigmetov
-  - name: Dmitriy Morozov
+  - Arnur Nigmetov
+  - Dmitriy Morozov
 tags:
   - merge-tree
   - benchmarking

--- a/content/research_papers/2022/2022-04-14-fast-merge-tree-computation-via-sycl.md
+++ b/content/research_papers/2022/2022-04-14-fast-merge-tree-computation-via-sycl.md
@@ -5,9 +5,7 @@ title: Fast Merge Tree Computation via SYCL
 external_url: https://arxiv.org/pdf/2301.10838.pdf
 authors:
   - name: Arnur Nigmetov
-    affiliation: Lawrence Berkeley National Laboratory
   - name: Dmitriy Morozov
-    affiliation: Lawrence Berkeley National Laboratory
 tags:
   - merge-tree
   - benchmarking

--- a/content/research_papers/2022/2022-07-10-a-benchmark-suite-for-improving-performance-portability-of-the-sycl-programming-model.md
+++ b/content/research_papers/2022/2022-07-10-a-benchmark-suite-for-improving-performance-portability-of-the-sycl-programming-model.md
@@ -4,8 +4,8 @@ date: '2022-07-10T08:08:10.490000+00:00'
 title: 'A Benchmark Suite for Improving Performance Portability of the SYCL Programming Model'
 external_url: https://ieeexplore.ieee.org/document/10158214
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - benchmarking
   - performance

--- a/content/research_papers/2022/2022-07-10-a-benchmark-suite-for-improving-performance-portability-of-the-sycl-programming-model.md
+++ b/content/research_papers/2022/2022-07-10-a-benchmark-suite-for-improving-performance-portability-of-the-sycl-programming-model.md
@@ -5,9 +5,7 @@ title: 'A Benchmark Suite for Improving Performance Portability of the SYCL Prog
 external_url: https://ieeexplore.ieee.org/document/10158214
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - benchmarking
   - performance

--- a/content/research_papers/2022/2022-10-28-portability and-performance-assessment-of-the-non-negative-matrix-factorization-algorithm-with-openmp-and-sycl.md
+++ b/content/research_papers/2022/2022-10-28-portability and-performance-assessment-of-the-non-negative-matrix-factorization-algorithm-with-openmp-and-sycl.md
@@ -5,11 +5,8 @@ title: 'Portability and Performance Assessment of the Non-Negative Matrix Factor
 external_url: https://ieeexplore.ieee.org/document/9959906
 authors:
   - name: Youssef Faqir-Rhazoui
-    affiliation: Universidad Complutense de Madrid
   - name: Carlos García
-    affiliation: Instituto de Tecnología del Conocimiento
   - name: Francisco Tirado
-    affiliation: Informática
 tags:
   - openmp
   - sycl

--- a/content/research_papers/2022/2022-10-28-portability and-performance-assessment-of-the-non-negative-matrix-factorization-algorithm-with-openmp-and-sycl.md
+++ b/content/research_papers/2022/2022-10-28-portability and-performance-assessment-of-the-non-negative-matrix-factorization-algorithm-with-openmp-and-sycl.md
@@ -4,9 +4,9 @@ date: '2022-10-28T08:08:10.490000+00:00'
 title: 'Portability and Performance Assessment of the Non-Negative Matrix Factorization Algorithm with OpenMP and SYCL'
 external_url: https://ieeexplore.ieee.org/document/9959906
 authors:
-  - name: Youssef Faqir-Rhazoui
-  - name: Carlos García
-  - name: Francisco Tirado
+  - Youssef Faqir-Rhazoui
+  - Carlos García
+  - Francisco Tirado
 tags:
   - openmp
   - sycl

--- a/content/research_papers/2022/2022-11-13-a-first-step-towards-support-for-mpi-partitioned-communication-on-sycl-programmed-fpg-as.md
+++ b/content/research_papers/2022/2022-11-13-a-first-step-towards-support-for-mpi-partitioned-communication-on-sycl-programmed-fpg-as.md
@@ -5,11 +5,8 @@ title: 'A First Step towards Support for MPI Partitioned Communication on SYCL-p
 external_url: https://ieeexplore.ieee.org/document/10027494
 authors:
   - name: Steffen Christgau
-    affiliation: Zuse Institute Berlin, Berlin
   - name: Marius Knaust
-    affiliation: Zuse Institute Berlin, Berlin
   - name: Thomas Steinke
-    affiliation: Zuse Institute Berlin, Berlin
 tags:
   - fpgas
   - mpi

--- a/content/research_papers/2022/2022-11-13-a-first-step-towards-support-for-mpi-partitioned-communication-on-sycl-programmed-fpg-as.md
+++ b/content/research_papers/2022/2022-11-13-a-first-step-towards-support-for-mpi-partitioned-communication-on-sycl-programmed-fpg-as.md
@@ -4,9 +4,9 @@ date: '2022-11-13T08:08:10.490000+00:00'
 title: 'A First Step towards Support for MPI Partitioned Communication on SYCL-programmed FPGAs'
 external_url: https://ieeexplore.ieee.org/document/10027494
 authors:
-  - name: Steffen Christgau
-  - name: Marius Knaust
-  - name: Thomas Steinke
+  - Steffen Christgau
+  - Marius Knaust
+  - Thomas Steinke
 tags:
   - fpgas
   - mpi

--- a/content/research_papers/2022/2022-11-13-towards-cross-platform-portability-of-coupled-cluster-methods-with-perturbative-triples-using-sycl.md
+++ b/content/research_papers/2022/2022-11-13-towards-cross-platform-portability-of-coupled-cluster-methods-with-perturbative-triples-using-sycl.md
@@ -4,10 +4,10 @@ date: '2022-11-13T08:08:10.490000+00:00'
 title: 'Towards Cross-Platform Portability of Coupled-Cluster Methods with Perturbative Triples using SYCL'
 external_url: https://ieeexplore.ieee.org/document/10024604
 authors:
-  - name: Abhishek Bagusetty
-  - name: Ajay Panyala
-  - name: Gordon Brown
-  - name: Jack Kirk
+  - Abhishek Bagusetty
+  - Ajay Panyala
+  - Gordon Brown
+  - Jack Kirk
 tags:
   - performance
   - nvidia

--- a/content/research_papers/2022/2022-11-13-towards-cross-platform-portability-of-coupled-cluster-methods-with-perturbative-triples-using-sycl.md
+++ b/content/research_papers/2022/2022-11-13-towards-cross-platform-portability-of-coupled-cluster-methods-with-perturbative-triples-using-sycl.md
@@ -5,13 +5,9 @@ title: 'Towards Cross-Platform Portability of Coupled-Cluster Methods with Pertu
 external_url: https://ieeexplore.ieee.org/document/10024604
 authors:
   - name: Abhishek Bagusetty
-    affiliation: Argonne National Laboratory
   - name: Ajay Panyala
-    affiliation: Pacific Northwest National Laboratory
   - name: Gordon Brown
-    affiliation: Codeplay Software Ltd
   - name: Jack Kirk
-    affiliation: Codeplay Software Ltd
 tags:
   - performance
   - nvidia

--- a/content/research_papers/2022/2022-11-18-evaluating-nonuniform-reduction-in-hip-and-sycl-on-gp-us.md
+++ b/content/research_papers/2022/2022-11-18-evaluating-nonuniform-reduction-in-hip-and-sycl-on-gp-us.md
@@ -4,8 +4,8 @@ date: '2022-11-18T08:08:10.490000+00:00'
 title: 'Evaluating Nonuniform Reduction in HIP and SYCL on GPUs'
 external_url: https://ieeexplore.ieee.org/document/10025472
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - reduction
   - nonuniform

--- a/content/research_papers/2022/2022-11-18-evaluating-nonuniform-reduction-in-hip-and-sycl-on-gp-us.md
+++ b/content/research_papers/2022/2022-11-18-evaluating-nonuniform-reduction-in-hip-and-sycl-on-gp-us.md
@@ -5,9 +5,7 @@ title: 'Evaluating Nonuniform Reduction in HIP and SYCL on GPUs'
 external_url: https://ieeexplore.ieee.org/document/10025472
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - reduction
   - nonuniform

--- a/content/research_papers/2022/2022-12-01-performance-study-of-gpu-applications-using-sycl-and-cuda-on-tesla-v100-gpu.md
+++ b/content/research_papers/2022/2022-12-01-performance-study-of-gpu-applications-using-sycl-and-cuda-on-tesla-v100-gpu.md
@@ -5,11 +5,8 @@ title: 'Performance Study of GPU applications using SYCL and CUDA on Tesla V100 
 external_url: https://ieeexplore.ieee.org/document/9622813
 authors:
   - name: Goutham Kalikrishna Reddy Kuncham
-    affiliation: NextGen R&D
   - name: Rahul Vaidya
-    affiliation: NextGen R&D
   - name: Mahesh Barve
-    affiliation: HPC Center Of Excellence
 tags:
   - performance
   - runtime

--- a/content/research_papers/2022/2022-12-01-performance-study-of-gpu-applications-using-sycl-and-cuda-on-tesla-v100-gpu.md
+++ b/content/research_papers/2022/2022-12-01-performance-study-of-gpu-applications-using-sycl-and-cuda-on-tesla-v100-gpu.md
@@ -4,9 +4,9 @@ date: '2022-12-01T08:08:10.490000+00:00'
 title: 'Performance Study of GPU applications using SYCL and CUDA on Tesla V100 GPU'
 external_url: https://ieeexplore.ieee.org/document/9622813
 authors:
-  - name: Goutham Kalikrishna Reddy Kuncham
-  - name: Rahul Vaidya
-  - name: Mahesh Barve
+  - Goutham Kalikrishna Reddy Kuncham
+  - Rahul Vaidya
+  - Mahesh Barve
 tags:
   - performance
   - runtime

--- a/content/research_papers/2022/2022-12-06-understanding-performance-portability-of-bioinformatics-applications-in-sycl-on-an-nvidia-gpu.md
+++ b/content/research_papers/2022/2022-12-06-understanding-performance-portability-of-bioinformatics-applications-in-sycl-on-an-nvidia-gpu.md
@@ -4,8 +4,8 @@ date: '2022-12-06T08:08:10.490000+00:00'
 title: 'Understanding Performance Portability of Bioinformatics Applications in SYCL on an NVIDIA GPU'
 external_url: https://ieeexplore.ieee.org/document/9995222
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - performance
   - nvidia

--- a/content/research_papers/2022/2022-12-06-understanding-performance-portability-of-bioinformatics-applications-in-sycl-on-an-nvidia-gpu.md
+++ b/content/research_papers/2022/2022-12-06-understanding-performance-portability-of-bioinformatics-applications-in-sycl-on-an-nvidia-gpu.md
@@ -5,9 +5,7 @@ title: 'Understanding Performance Portability of Bioinformatics Applications in 
 external_url: https://ieeexplore.ieee.org/document/9995222
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - performance
   - nvidia

--- a/content/research_papers/2022/2022-12-23-a-memory-bank-conflict-prevention-mechanism-for-sycl-on-sx-aurora-tsubasa.md
+++ b/content/research_papers/2022/2022-12-23-a-memory-bank-conflict-prevention-mechanism-for-sycl-on-sx-aurora-tsubasa.md
@@ -5,13 +5,9 @@ title: 'A memory bank conflict prevention mechanism for SYCL on SX-Aurora TSUBAS
 external_url: https://ieeexplore.ieee.org/document/9644088
 authors:
   - name: Wenbin Wang
-    affiliation: Tohoku University
   - name: Jiahao Li
-    affiliation: Tohoku University
   - name: Yohichi Shimomura
-    affiliation: Tohoku University
   - name: Hiroyuki Takizawa
-    affiliation: Tohoku University
 tags:
   - performance
   - runtime

--- a/content/research_papers/2022/2022-12-23-a-memory-bank-conflict-prevention-mechanism-for-sycl-on-sx-aurora-tsubasa.md
+++ b/content/research_papers/2022/2022-12-23-a-memory-bank-conflict-prevention-mechanism-for-sycl-on-sx-aurora-tsubasa.md
@@ -4,10 +4,10 @@ date: '2022-12-23T08:08:10.490000+00:00'
 title: 'A memory bank conflict prevention mechanism for SYCL on SX-Aurora TSUBASA'
 external_url: https://ieeexplore.ieee.org/document/9644088
 authors:
-  - name: Wenbin Wang
-  - name: Jiahao Li
-  - name: Yohichi Shimomura
-  - name: Hiroyuki Takizawa
+  - Wenbin Wang
+  - Jiahao Li
+  - Yohichi Shimomura
+  - Hiroyuki Takizawa
 tags:
   - performance
   - runtime

--- a/content/research_papers/2023/2023-05-15-remote-execution-of-open-cl-and-sycl-applications-via-r-open-cl.md
+++ b/content/research_papers/2023/2023-05-15-remote-execution-of-open-cl-and-sycl-applications-via-r-open-cl.md
@@ -4,8 +4,8 @@ date: '2023-05-15T08:08:10.490000+00:00'
 title: 'Remote Execution of OpenCL and SYCL Applications via rOpenCL'
 external_url: https://ieeexplore.ieee.org/document/10196646
 authors:
-  - name: Rui Alves
-  - name: José Rufino
+  - Rui Alves
+  - José Rufino
 tags:
   - hpc
   - api

--- a/content/research_papers/2023/2023-05-15-remote-execution-of-open-cl-and-sycl-applications-via-r-open-cl.md
+++ b/content/research_papers/2023/2023-05-15-remote-execution-of-open-cl-and-sycl-applications-via-r-open-cl.md
@@ -5,9 +5,7 @@ title: 'Remote Execution of OpenCL and SYCL Applications via rOpenCL'
 external_url: https://ieeexplore.ieee.org/document/10196646
 authors:
   - name: Rui Alves
-    affiliation: Instituto Politécnico de Bragança Campus de Santa Apolónia
   - name: José Rufino
-    affiliation: Instituto Politécnico de Bragança
 tags:
   - hpc
   - api

--- a/content/research_papers/2023/2023-05-15-understanding-performance-portability-of-sycl-kernels-a-case-study-with-the-all-pairs-distance-calculation-in-bioinformatics-on-gp-us.md
+++ b/content/research_papers/2023/2023-05-15-understanding-performance-portability-of-sycl-kernels-a-case-study-with-the-all-pairs-distance-calculation-in-bioinformatics-on-gp-us.md
@@ -4,8 +4,8 @@ date: '2023-05-15T08:08:10.490000+00:00'
 title: 'Understanding Performance Portability of SYCL Kernels: A Case Study with the All-Pairs Distance Calculation in Bioinformatics on GPUs'
 external_url: https://ieeexplore.ieee.org/document/10196541
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - portability
   - performance

--- a/content/research_papers/2023/2023-05-15-understanding-performance-portability-of-sycl-kernels-a-case-study-with-the-all-pairs-distance-calculation-in-bioinformatics-on-gp-us.md
+++ b/content/research_papers/2023/2023-05-15-understanding-performance-portability-of-sycl-kernels-a-case-study-with-the-all-pairs-distance-calculation-in-bioinformatics-on-gp-us.md
@@ -5,9 +5,7 @@ title: 'Understanding Performance Portability of SYCL Kernels: A Case Study with
 external_url: https://ieeexplore.ieee.org/document/10196541
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - portability
   - performance

--- a/content/research_papers/2023/2023-05-15-understanding-sycl-portability-for-pseudorandom-number-generation-a-case-study-with-gene-expression-connectivity-mapping.md
+++ b/content/research_papers/2023/2023-05-15-understanding-sycl-portability-for-pseudorandom-number-generation-a-case-study-with-gene-expression-connectivity-mapping.md
@@ -5,9 +5,7 @@ title: 'Understanding SYCL Portability for Pseudorandom Number Generation: a Cas
 external_url: https://ieeexplore.ieee.org/document/10196601
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - portability
   - pseudorandom

--- a/content/research_papers/2023/2023-05-15-understanding-sycl-portability-for-pseudorandom-number-generation-a-case-study-with-gene-expression-connectivity-mapping.md
+++ b/content/research_papers/2023/2023-05-15-understanding-sycl-portability-for-pseudorandom-number-generation-a-case-study-with-gene-expression-connectivity-mapping.md
@@ -4,8 +4,8 @@ date: '2023-05-15T08:08:10.490000+00:00'
 title: 'Understanding SYCL Portability for Pseudorandom Number Generation: a Case Study with Gene-Expression Connectivity Mapping'
 external_url: https://ieeexplore.ieee.org/document/10196601
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - portability
   - pseudorandom

--- a/content/research_papers/2023/2023-09-05-experience-migrating-open-cl-to-sycl-a-case-study-on-searches-for-potential-off-target-sites-of-cas-9-rna-guided-endonucleases-on-amd-gp-us.md
+++ b/content/research_papers/2023/2023-09-05-experience-migrating-open-cl-to-sycl-a-case-study-on-searches-for-potential-off-target-sites-of-cas-9-rna-guided-endonucleases-on-amd-gp-us.md
@@ -4,8 +4,8 @@ date: '2023-09-05T08:08:10.490000+00:00'
 title: 'Experience Migrating OpenCL to SYCL: A Case Study on Searches for Potential Off-Target Sites of Cas9 RNA-Guided Endonucleases on AMD GPUs'
 external_url: https://ieeexplore.ieee.org/document/10256881
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - sequence
   - analysis

--- a/content/research_papers/2023/2023-09-05-experience-migrating-open-cl-to-sycl-a-case-study-on-searches-for-potential-off-target-sites-of-cas-9-rna-guided-endonucleases-on-amd-gp-us.md
+++ b/content/research_papers/2023/2023-09-05-experience-migrating-open-cl-to-sycl-a-case-study-on-searches-for-potential-off-target-sites-of-cas-9-rna-guided-endonucleases-on-amd-gp-us.md
@@ -5,9 +5,7 @@ title: 'Experience Migrating OpenCL to SYCL: A Case Study on Searches for Potent
 external_url: https://ieeexplore.ieee.org/document/10256881
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - sequence
   - analysis

--- a/content/research_papers/2023/2023-10-17-comparing-performance-and-portability-between-cuda-and-sycl-for-protein-database-search-on-nvidia-amd-and-intel-gp-us.md
+++ b/content/research_papers/2023/2023-10-17-comparing-performance-and-portability-between-cuda-and-sycl-for-protein-database-search-on-nvidia-amd-and-intel-gp-us.md
@@ -5,15 +5,10 @@ title: 'Comparing Performance and Portability Between CUDA and SYCL for Protein 
 external_url: https://ieeexplore.ieee.org/document/10306194
 authors:
   - name: Manuel Costanzo
-    affiliation: UNLP - CIC, La Plata
   - name: Enzo Rucci
-    affiliation: UNLP - CIC, La Plata
   - name: Carlos García-Sánchez
-    affiliation: Universidad Complutense de Madrid
   - name: Marcelo Naiouf
-    affiliation: UNLP - CIC, La Plata
   - name: Manuel Prieto-Matías
-    affiliation: Universidad Complutense de Madrid
 tags:
   - cuda
   - gpu

--- a/content/research_papers/2023/2023-10-17-comparing-performance-and-portability-between-cuda-and-sycl-for-protein-database-search-on-nvidia-amd-and-intel-gp-us.md
+++ b/content/research_papers/2023/2023-10-17-comparing-performance-and-portability-between-cuda-and-sycl-for-protein-database-search-on-nvidia-amd-and-intel-gp-us.md
@@ -4,11 +4,11 @@ date: '2023-10-17T08:08:10.490000+00:00'
 title: 'Comparing Performance and Portability Between CUDA and SYCL for Protein Database Search on NVIDIA, AMD, and Intel GPUs'
 external_url: https://ieeexplore.ieee.org/document/10306194
 authors:
-  - name: Manuel Costanzo
-  - name: Enzo Rucci
-  - name: Carlos García-Sánchez
-  - name: Marcelo Naiouf
-  - name: Manuel Prieto-Matías
+  - Manuel Costanzo
+  - Enzo Rucci
+  - Carlos García-Sánchez
+  - Marcelo Naiouf
+  - Manuel Prieto-Matías
 tags:
   - cuda
   - gpu

--- a/content/research_papers/2023/2023-10-31-accelerating-hyperdimensional-classifier-with-sycl.md
+++ b/content/research_papers/2023/2023-10-31-accelerating-hyperdimensional-classifier-with-sycl.md
@@ -4,8 +4,8 @@ date: '2023-10-31T08:08:10.490000+00:00'
 title: 'Accelerating Hyperdimensional Classifier with SYCL'
 external_url: https://ieeexplore.ieee.org/document/10321902
 authors:
-  - name: Zheming Jin
-  - name: Jeffrey S. Vetter
+  - Zheming Jin
+  - Jeffrey S. Vetter
 tags:
   - parallel
   - search

--- a/content/research_papers/2023/2023-10-31-accelerating-hyperdimensional-classifier-with-sycl.md
+++ b/content/research_papers/2023/2023-10-31-accelerating-hyperdimensional-classifier-with-sycl.md
@@ -5,9 +5,7 @@ title: 'Accelerating Hyperdimensional Classifier with SYCL'
 external_url: https://ieeexplore.ieee.org/document/10321902
 authors:
   - name: Zheming Jin
-    affiliation: Oak Ridge National Laboratory
   - name: Jeffrey S. Vetter
-    affiliation: Oak Ridge National Laboratory
 tags:
   - parallel
   - search

--- a/content/research_papers/2023/2023-12-18-migration-of-cuda-based-seismic-application-to-cross-platform-sycl-implementation.md
+++ b/content/research_papers/2023/2023-12-18-migration-of-cuda-based-seismic-application-to-cross-platform-sycl-implementation.md
@@ -4,13 +4,13 @@ date: '2023-12-18T08:08:10.490000+00:00'
 title: 'Migration of CUDA Based Seismic Application to Cross-Platform SYCL Implementation'
 external_url: https://ieeexplore.ieee.org/document/10502402
 authors:
-  - name: Om Jadhav
-  - name: Sandeep Agrawal
-  - name: Abhishek Srivastava
-  - name: Richa Rastogi
-  - name: Sanjay Wandhekar
-  - name: Vinutha SV
-  - name: Jyotsna Khemka
+  - Om Jadhav
+  - Sandeep Agrawal
+  - Abhishek Srivastava
+  - Richa Rastogi
+  - Sanjay Wandhekar
+  - Vinutha SV
+  - Jyotsna Khemka
 tags:
   - acoustic-waves
   - seismic-data

--- a/content/research_papers/2023/2023-12-18-migration-of-cuda-based-seismic-application-to-cross-platform-sycl-implementation.md
+++ b/content/research_papers/2023/2023-12-18-migration-of-cuda-based-seismic-application-to-cross-platform-sycl-implementation.md
@@ -5,19 +5,12 @@ title: 'Migration of CUDA Based Seismic Application to Cross-Platform SYCL Imple
 external_url: https://ieeexplore.ieee.org/document/10502402
 authors:
   - name: Om Jadhav
-    affiliation: HPC-Technologies Group
   - name: Sandeep Agrawal
-    affiliation: HPC-Technologies Group
   - name: Abhishek Srivastava
-    affiliation: HPC-SE&A Group
   - name: Richa Rastogi
-    affiliation: HPC-SE&A Group
   - name: Sanjay Wandhekar
-    affiliation: HPC-Technologies Group
   - name: Vinutha SV
-    affiliation: Intel Technology India Pvt. Ltd
   - name: Jyotsna Khemka
-    affiliation: Intel Technology India Pvt. Ltd
 tags:
   - acoustic-waves
   - seismic-data

--- a/content/research_papers/2023/2023-12-21-evaluating-performance-portability-of-sycl-and-kokkos-a-case-study-on-lbm-simulations.md
+++ b/content/research_papers/2023/2023-12-21-evaluating-performance-portability-of-sycl-and-kokkos-a-case-study-on-lbm-simulations.md
@@ -4,13 +4,13 @@ date: '2023-12-21T08:08:10.490000+00:00'
 title: 'Evaluating Performance Portability of SYCL and Kokkos: A Case Study on LBM Simulations'
 external_url: https://ieeexplore.ieee.org/document/10491773
 authors:
-  - name: Yue Ding
-  - name: Chuanfu Xu
-  - name: Haozhong Qiu
-  - name: Qingsong Wang
-  - name: Weixi Dai
-  - name: Yongzhen Lin
-  - name: Yonggang Che
+  - Yue Ding
+  - Chuanfu Xu
+  - Haozhong Qiu
+  - Qingsong Wang
+  - Weixi Dai
+  - Yongzhen Lin
+  - Yonggang Che
 tags:
   - kokkos
   - performance

--- a/content/research_papers/2023/2023-12-21-evaluating-performance-portability-of-sycl-and-kokkos-a-case-study-on-lbm-simulations.md
+++ b/content/research_papers/2023/2023-12-21-evaluating-performance-portability-of-sycl-and-kokkos-a-case-study-on-lbm-simulations.md
@@ -5,19 +5,12 @@ title: 'Evaluating Performance Portability of SYCL and Kokkos: A Case Study on L
 external_url: https://ieeexplore.ieee.org/document/10491773
 authors:
   - name: Yue Ding
-    affiliation: National University of Defense Technology
   - name: Chuanfu Xu
-    affiliation: National University of Defense Technology
   - name: Haozhong Qiu
-    affiliation: National University of Defense Technology
   - name: Qingsong Wang
-    affiliation: National University of Defense Technology
   - name: Weixi Dai
-    affiliation: National University of Defense Technology
   - name: Yongzhen Lin
-    affiliation: National University of Defense Technology
   - name: Yonggang Che
-    affiliation: National University of Defense Technology
 tags:
   - kokkos
   - performance

--- a/content/research_papers/2024/2024-03-02-experiences-building-an-mlir-based-sycl-compiler.md
+++ b/content/research_papers/2024/2024-03-02-experiences-building-an-mlir-based-sycl-compiler.md
@@ -4,14 +4,14 @@ date: '2024-03-02T08:08:10.490000+00:00'
 title: 'Experiences Building an MLIR-Based SYCL Compiler'
 external_url: https://ieeexplore.ieee.org/document/10444866
 authors:
-  - name: Ettore Tiotto
-  - name: Víctor Pérez
-  - name: Whitney Tsang
-  - name: Lukas Sommer
-  - name: Julian Oppermann
-  - name: Victor Lomüller
-  - name: Mehdi Goli
-  - name: James Brodman
+  - Ettore Tiotto
+  - Víctor Pérez
+  - Whitney Tsang
+  - Lukas Sommer
+  - Julian Oppermann
+  - Victor Lomüller
+  - Mehdi Goli
+  - James Brodman
 tags:
   - SYCL
   - MLIR

--- a/content/research_papers/2024/2024-03-02-experiences-building-an-mlir-based-sycl-compiler.md
+++ b/content/research_papers/2024/2024-03-02-experiences-building-an-mlir-based-sycl-compiler.md
@@ -5,21 +5,13 @@ title: 'Experiences Building an MLIR-Based SYCL Compiler'
 external_url: https://ieeexplore.ieee.org/document/10444866
 authors:
   - name: Ettore Tiotto
-    affiliation: Intel Corporation
   - name: Víctor Pérez
-    affiliation: Codeplay Software
   - name: Whitney Tsang
-    affiliation: Intel Corporation
   - name: Lukas Sommer
-    affiliation: Codeplay Software
   - name: Julian Oppermann
-    affiliation: Codeplay Software
   - name: Victor Lomüller
-    affiliation: Codeplay Software
   - name: Mehdi Goli
-    affiliation: Codeplay Software
   - name: James Brodman
-    affiliation: Intel Corporation
 tags:
   - SYCL
   - MLIR

--- a/content/research_papers/2024/2024-05-20-unveiling-performance-insights-and-portability-achievements-between-cuda-and-sycl-for-particle-in-cell-codes-on-different-gpu-architectures.md
+++ b/content/research_papers/2024/2024-05-20-unveiling-performance-insights-and-portability-achievements-between-cuda-and-sycl-for-particle-in-cell-codes-on-different-gpu-architectures.md
@@ -4,10 +4,10 @@ date: '2024-05-20T08:08:10.490000+00:00'
 title: 'Unveiling Performance Insights and Portability Achievements Between CUDA and SYCL for Particle-in-Cell Codes on Different GPU Architectures'
 external_url: https://ieeexplore.ieee.org/document/10569866
 authors:
-  - name: Ivona Vasileska
-  - name: Pavel Tomšič
-  - name: Leon Kos
-  - name: Leon Bogdanović
+  - Ivona Vasileska
+  - Pavel Tomšič
+  - Leon Kos
+  - Leon Bogdanović
 tags:
   - gpu
   - cuda

--- a/content/research_papers/2024/2024-05-20-unveiling-performance-insights-and-portability-achievements-between-cuda-and-sycl-for-particle-in-cell-codes-on-different-gpu-architectures.md
+++ b/content/research_papers/2024/2024-05-20-unveiling-performance-insights-and-portability-achievements-between-cuda-and-sycl-for-particle-in-cell-codes-on-different-gpu-architectures.md
@@ -5,13 +5,9 @@ title: 'Unveiling Performance Insights and Portability Achievements Between CUDA
 external_url: https://ieeexplore.ieee.org/document/10569866
 authors:
   - name: Ivona Vasileska
-    affiliation: University of Ljubljana
   - name: Pavel Tomšič
-    affiliation: University of Ljubljana
   - name: Leon Kos
-    affiliation: University of Ljubljana
   - name: Leon Bogdanović
-    affiliation: University of Ljubljana
 tags:
   - gpu
   - cuda

--- a/content/research_papers/README.md
+++ b/content/research_papers/README.md
@@ -13,8 +13,8 @@ date: '2022-04-14T08:08:10'
 title: My Research Paper
 external_url: https://link-to-paper.com/research-paper-1
 authors:
-  - name: John Smith
-  - name: Alice Ryan
+  - John Smith
+  - Alice Ryan
 ---
 
 Your description of the research paper here.

--- a/content/research_papers/README.md
+++ b/content/research_papers/README.md
@@ -14,9 +14,7 @@ title: My Research Paper
 external_url: https://link-to-paper.com/research-paper-1
 authors:
   - name: John Smith
-    affiliation: University of Sycl
   - name: Alice Ryan
-    affiliation: University of Space
 ---
 
 Your description of the research paper here.

--- a/src/feeds/ResearchPaperFeed.py
+++ b/src/feeds/ResearchPaperFeed.py
@@ -55,4 +55,7 @@ class ResearchPaperFeed(BaseJsonFeed):
 
             filters.add_filter('year', feed_item.markdown_file.date.year)
 
+            if feed_item.has_value('authors'):
+                [filters.add_filter('authors', author) for author in feed_item.get('authors')]
+
         return filters

--- a/src/feeds/ResearchPaperFeed.py
+++ b/src/feeds/ResearchPaperFeed.py
@@ -18,9 +18,7 @@
 #
 
 from markdownfeeds.Generators.Default.Models.FeedItem import FeedItem
-from markdownfeeds.Generators.Json.Models.Author import Author
 from markdownfeeds.Generators.Json.Models.JsonFeedItem import JsonFeedItem
-from markdownfeeds.MarkdownFile import MarkdownFile
 
 from src.feeds import BaseJsonFeed, Filters
 
@@ -37,14 +35,6 @@ class ResearchPaperFeed(BaseJsonFeed):
         super()._check_feed_items(feed_items)
         BaseJsonFeed._check_for_duplicates(feed_items, 'external_url')
 
-    def _inject_feed_item_details(
-            self, feed_item: JsonFeedItem, markdown_file: MarkdownFile) -> JsonFeedItem:
-        """
-        Inject any additional feed item details.
-        """
-        feed_item = self._inject_authors_into_featured(feed_item)
-        return super()._inject_feed_item_details(feed_item, markdown_file)
-
     def _sort_feed_items(
             self, feed_items: [FeedItem]) -> [FeedItem]:
         """
@@ -52,26 +42,6 @@ class ResearchPaperFeed(BaseJsonFeed):
         """
         feed_items.sort(key=lambda feed_item: feed_item.get('date_published'), reverse=True)
         return feed_items
-
-    @staticmethod
-    def _inject_authors_into_featured(
-        feed_item: JsonFeedItem
-    ) -> JsonFeedItem:
-        """
-        This function replaces any "authors" list items that reference a contributor using their username with
-        their contributor profile.
-        """
-        if not feed_item.has('authors'):
-            return feed_item
-
-        authors = feed_item.get('authors')
-        for key, value in enumerate(authors):
-            author = Author()
-            author.inject_dict(value)
-            authors[key] = author
-
-        feed_item.set('authors', authors)
-        return feed_item
 
     def _generate_filters(
         self,


### PR DESCRIPTION
The original idea was to have authors affiliated to companies/institutions and shown within the UI. Unfortunately, its a little hairy, especially when people are listed as affiliates but have moved on/no longer work with the original affiliation. 

This PR removes the affiliation but retrains the authors.