### PR TITLE
Fix For Broken Authors on Research Papers

### DIFF
--- a/content/research_papers/2023/2023-10-01-open-sycl-on-heterogeneous-gpu-systems-a-case-of-study.md
+++ b/content/research_papers/2023/2023-10-01-open-sycl-on-heterogeneous-gpu-systems-a-case-of-study.md
@@ -4,11 +4,11 @@ date: '2023-10-01T08:08:10.490000'
 title: 'Open SYCL on heterogeneous GPU systems: A case of study'
 external_url: https://arxiv.org/ftp/arxiv/papers/2310/2310.06947.pdf
 authors:
-  - name: Rocío Carratalá-Sáez
-  - name: Francisco J. Andújar
-  - name: Yuri Torres
-  - name: Arturo Gonzalez-Escribano
-  - name: Diego R. Llanos
+  - Rocío Carratalá-Sáez
+  - Francisco J. Andújar
+  - Yuri Torres
+  - Arturo Gonzalez-Escribano
+  - Diego R. Llanos
 tags:
   - gpu
   - cuda

--- a/content/research_papers/2023/2023-10-24-a-performance-portable-sycl-implementation-of-crk-hacc-for-exascale.md
+++ b/content/research_papers/2023/2023-10-24-a-performance-portable-sycl-implementation-of-crk-hacc-for-exascale.md
@@ -4,12 +4,12 @@ date: '2023-10-24T08:08:10.490000'
 title: 'A Performance-Portable SYCL Implementation of CRK-HACC for Exascale'
 external_url: https://arxiv.org/pdf/2310.16122
 authors:
-  - name: Esteban M. Rangel
-  - name: S. John Pennycook
-  - name: Adrian Pope
-  - name: Nicholas Frontiere
-  - name: Zhiqiang Ma
-  - name: Varsha Madananth
+  - Esteban M. Rangel
+  - S. John Pennycook
+  - Adrian Pope
+  - Nicholas Frontiere
+  - Zhiqiang Ma
+  - Varsha Madananth
 tags:
   - sycl
   - hpc

--- a/content/research_papers/2024/2024-01-05-preliminary-report-initial-evaluation-of-stdpar-implementations-on-amd-gpus-for-hpc.md
+++ b/content/research_papers/2024/2024-01-05-preliminary-report-initial-evaluation-of-stdpar-implementations-on-amd-gpus-for-hpc.md
@@ -4,9 +4,9 @@ date: '2024-01-05T08:08:10.490000'
 title: 'Preliminary report: Initial evaluation of StdPar implementations on AMD GPUs for HPC'
 external_url: https://arxiv.org/pdf/2401.02680
 authors:
-  - name: Wei-Chen Lin
-  - name: Simon McIntosh-Smith
-  - name: Tom Deakin
+  - Wei-Chen Lin
+  - Simon McIntosh-Smith
+  - Tom Deakin
 tags:
   - sycl
   - gpu

--- a/content/research_papers/2024/2024-01-24-lessons-learned-migrating-cuda-to-sycl-a-hep-case-study-with-root-rdataframe.md
+++ b/content/research_papers/2024/2024-01-24-lessons-learned-migrating-cuda-to-sycl-a-hep-case-study-with-root-rdataframe.md
@@ -4,9 +4,9 @@ date: '2024-01-24T08:08:10.490000'
 title: 'Lessons Learned Migrating CUDA to SYCL: A HEP Case Study with ROOT RDataFrame'
 external_url: https://arxiv.org/pdf/2401.13310
 authors:
-  - name: Jolly Chen
-  - name: Monica Dessole
-  - name: Ana Lucia Varbanescu
+  - Jolly Chen
+  - Monica Dessole
+  - Ana Lucia Varbanescu
 tags:
   - sycl
   - gpu

--- a/content/research_papers/2024/2024-03-09-xfluids-a-sycl-based-unified-cross-architecture-heterogeneous-simulation-solver-for-compressible-reacting-flows.md
+++ b/content/research_papers/2024/2024-03-09-xfluids-a-sycl-based-unified-cross-architecture-heterogeneous-simulation-solver-for-compressible-reacting-flows.md
@@ -4,8 +4,8 @@ date: '2024-03-09T08:08:10.490000'
 title: 'XFLUIDS: A SYCL-based unified cross-architecture heterogeneous simulation solver for compressible reacting flows'
 external_url: https://arxiv.org/abs/2403.05910
 authors:
-  - name: Jinlong Li
-  - name: Shucheng Pan
+  - Jinlong Li
+  - Shucheng Pan
 tags:
   - sycl
   - hpc

--- a/content/research_papers/2024/2024-04-16-enabling-performance-portability-on-the-ligen-drug-discovery-pipeline.md
+++ b/content/research_papers/2024/2024-04-16-enabling-performance-portability-on-the-ligen-drug-discovery-pipeline.md
@@ -4,15 +4,15 @@ date: '2024-04-16T08:08:10.490000'
 title: 'Enabling performance portability on the LiGen drug discovery pipeline'
 external_url: https://www.sciencedirect.com/science/article/pii/S0167739X24001195
 authors:
-  - name: Luigi Crisci
-  - name: Lorenzo Carpentieri
-  - name: Biagio Cosenza
-  - name: Leon Bogdanović
-  - name: Gianmarco Accordi
-  - name: Davide Gadioli
-  - name: Emanuele Vitali
-  - name: Gianluca Palermo
-  - name: Andrea Rosario Beccari
+  - Luigi Crisci
+  - Lorenzo Carpentieri
+  - Biagio Cosenza
+  - Leon Bogdanović
+  - Gianmarco Accordi
+  - Davide Gadioli
+  - Emanuele Vitali
+  - Gianluca Palermo
+  - Andrea Rosario Beccari
 tags:
   - gpu
   - sycl


### PR DESCRIPTION
This PR fixes authors being rendered as objects in the front-end.

Fixes #21