### PR TITLE
Adds a missing featuring meta to the RISC-V accelerators video.

### DIFF
--- a/content/videos/2024/2024-07-05-bring-your-code-to-riscv-accelerators-with-sycl.md
+++ b/content/videos/2024/2024-07-05-bring-your-code-to-riscv-accelerators-with-sycl.md
@@ -7,6 +7,9 @@ type: presentation
 tags:
   - hpc
   - risc-v
+featuring:
+  - name: Charles MacFarlane
+    affiliation_at_video_production_time: Codeplay Software
 ---
 
 This talk will show attendees how to overcome proprietary code with RISC-V and SYCL. They will learn how they can


### PR DESCRIPTION
Adds a missing "featuring" header.